### PR TITLE
chore(integration): disable info logs during tests setup

### DIFF
--- a/testing/suites/integration/setup/after-env/set-app.ts
+++ b/testing/suites/integration/setup/after-env/set-app.ts
@@ -16,6 +16,7 @@ beforeAll(async () => {
     try {
         // Disable debug logs
         jest.spyOn(SystemLogger.getInstance(), 'debug').mockImplementation();
+        jest.spyOn(SystemLogger.getInstance(), 'log').mockImplementation();
 
         // Application
         const testingModule: TestingModule = await Test.createTestingModule({


### PR DESCRIPTION
# Pull Request

## Description
Disable info logs in integration tests setup.

## Changes Overview
- Added the following line `jest.spyOn(SystemLogger.getInstance(), 'log').mockImplementation();` in app setup.

## Type of Change
- [ ] **Bug fix** 
- [ ] **New feature** 
- [ ] **Breaking change**
- [x] **Refactor** 
- [ ] **Test** 
- [ ] **Documentation**

## Test Coverage
- [ ] Unit tests
- [ ] Components tests
- [ ] Integration tests
- [ ] E2E tests
- [x] No new tests required