### PR TITLE
Feat/Add option in gql operations factory  to allow custom appended operations

### DIFF
--- a/testing/tools/gql-operations/factory/operation.factory.ts
+++ b/testing/tools/gql-operations/factory/operation.factory.ts
@@ -10,9 +10,9 @@ export function operationFactory(
         operationType = 'mutation',
         modelDataFetched = 'account',
     }: IOperationInfo,
-    { args, fields }: IOperation,
+    { args, fields, append = '' }: IOperation,
 ) {
-    let dataFetched: string;
+    let dataFetched: string = '';
 
     if (fields === 'ALL') {
         switch (modelDataFetched) {
@@ -31,6 +31,8 @@ export function operationFactory(
     } else {
         dataFetched = fields ? fields.join() : '';
     }
+
+    dataFetched = dataFetched + `, ${append}`;
 
     return {
         query: `

--- a/testing/tools/gql-operations/interfaces/operation.interface.ts
+++ b/testing/tools/gql-operations/interfaces/operation.interface.ts
@@ -7,4 +7,5 @@ import { QueryFields } from '../types/query-fields.type';
 export interface IOperation<InputType = unknown, ModelType = any> {
     readonly args: InputType;
     readonly fields?: QueryFields<ModelType>[] | 'ALL';
+    readonly append?: string;
 }


### PR DESCRIPTION
# Pull Request

## Description
Allow custom appended operations when generating a gql operation for testing.

## Changes Overview
- Added `append` option in **operationFactory**.
- Updated `IOperation` interface.

## Type of Change
- [ ] **Bug fix** 
- [ ] **New feature** 
- [ ] **Breaking change**
- [ ] **Refactor** 
- [x] **Test** 
- [ ] **Documentation**

## Test Coverage
- [ ] Unit tests
- [ ] Components tests
- [ ] Integration tests
- [ ] E2E tests
- [x] No new tests required