### PR TITLE
Feat/Add Advisory Lock on user-review in voting system

### DIFF
--- a/src/orchestrators/user-deletion/user-deletion.service.ts
+++ b/src/orchestrators/user-deletion/user-deletion.service.ts
@@ -16,7 +16,7 @@ export class UserDeletionService {
     async deleteOne(id: string): Promise<void> {
         await this.dataSource.transaction(async (manager: EntityManager) => {
             const user = await this.userService.findOneByIdOrThrowTx(id, manager);
-            await this.votesService.subtractUserVotesFromReviews(id, manager);
+            await this.votesService.revokeUserVotesOnReviewsTx(id, manager);
             await this.userService.deleteOneTx(user, manager);
         });
         await this.userService.deleteUserFromCache(id);

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -184,17 +184,17 @@ export class ReviewService {
      */
     async decrementVotesInTx({
         reviewsIds,
-        vote,
+        action,
         txManager,
         value = 0,
     }: {
         reviewsIds: string[];
-        vote: VoteAction;
+        action: VoteAction;
         txManager: EntityManager;
         value?: number;
     }): Promise<void> {
         if (reviewsIds.length === 0) return;
-        const propPath = vote === VoteAction.UP ? 'upVotes' : 'downVotes';
+        const propPath = action === VoteAction.UP ? 'upVotes' : 'downVotes';
         await txManager
             .withRepository(this.reviewRepository)
             .decrement({ id: In(reviewsIds) }, propPath, value);

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -144,12 +144,12 @@ export class ReviewService {
         reviewId,
         action,
         txManager,
-        value = 0,
+        value,
     }: {
         reviewId: string;
         action: VoteAction;
         txManager: EntityManager;
-        value?: number;
+        value: number;
     }): Promise<void> {
         const propPath = action === VoteAction.UP ? 'upVotes' : 'downVotes';
         await txManager
@@ -165,12 +165,12 @@ export class ReviewService {
         reviewId,
         action,
         txManager,
-        value = 0,
+        value,
     }: {
         reviewId: string;
         action: VoteAction;
         txManager: EntityManager;
-        value?: number;
+        value: number;
     }): Promise<void> {
         const propPath = action === VoteAction.UP ? 'upVotes' : 'downVotes';
         await txManager

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -136,30 +136,68 @@ export class ReviewService {
         });
     }
 
-    async addVoteTx(reviewId: string, vote: VoteAction, manager: EntityManager): Promise<void> {
-        const propPath = vote === VoteAction.UP ? 'upVotes' : 'downVotes';
-        await manager
+    /**
+     * Increments the upVotes or downVotes count of a review based on the provided action.
+     * This method is intended to be used within a transaction
+     */
+    async incrementVotesTx({
+        reviewId,
+        action,
+        txManager,
+        value = 0,
+    }: {
+        reviewId: string;
+        action: VoteAction;
+        txManager: EntityManager;
+        value?: number;
+    }): Promise<void> {
+        const propPath = action === VoteAction.UP ? 'upVotes' : 'downVotes';
+        await txManager
             .withRepository(this.reviewRepository)
-            .increment({ id: reviewId }, propPath, 1);
+            .increment({ id: reviewId }, propPath, value);
     }
 
-    async deleteVoteTx(reviewId: string, vote: VoteAction, manager: EntityManager): Promise<void> {
-        const propPath = vote === VoteAction.UP ? 'upVotes' : 'downVotes';
-        await manager
+    /**
+     * Decrements the upVotes or downVotes count of a review based on the provided action.
+     * This method is intended to be used within a transaction
+     */
+    async decrementVotesTx({
+        reviewId,
+        action,
+        txManager,
+        value = 0,
+    }: {
+        reviewId: string;
+        action: VoteAction;
+        txManager: EntityManager;
+        value?: number;
+    }): Promise<void> {
+        const propPath = action === VoteAction.UP ? 'upVotes' : 'downVotes';
+        await txManager
             .withRepository(this.reviewRepository)
-            .decrement({ id: reviewId }, propPath, 1);
+            .decrement({ id: reviewId }, propPath, value);
     }
 
-    async deleteVoteInMultipleReviews(
-        reviewsIds: string[],
-        vote: VoteAction,
-        manager: EntityManager,
-    ): Promise<void> {
+    /**
+     * Decrements the upVotes or downVotes count of multiple reviews based on the provided action.
+     * This method is intended to be used within a transaction
+     */
+    async decrementVotesInTx({
+        reviewsIds,
+        vote,
+        txManager,
+        value = 0,
+    }: {
+        reviewsIds: string[];
+        vote: VoteAction;
+        txManager: EntityManager;
+        value?: number;
+    }): Promise<void> {
         if (reviewsIds.length === 0) return;
         const propPath = vote === VoteAction.UP ? 'upVotes' : 'downVotes';
-        await manager
+        await txManager
             .withRepository(this.reviewRepository)
-            .decrement({ id: In(reviewsIds) }, propPath, 1);
+            .decrement({ id: In(reviewsIds) }, propPath, value);
     }
 
     async calculateItemAverageRating(itemId: string): Promise<number> {

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -186,12 +186,12 @@ export class ReviewService {
         reviewsIds,
         action,
         txManager,
-        value = 0,
+        value,
     }: {
         reviewsIds: string[];
         action: VoteAction;
         txManager: EntityManager;
-        value?: number;
+        value: number;
     }): Promise<void> {
         if (reviewsIds.length === 0) return;
         const propPath = action === VoteAction.UP ? 'upVotes' : 'downVotes';

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -27,52 +27,62 @@ export class VotesService {
      * @returns boolean indicating whether the lock was acquired or not.
      */
     async acquireVoteLock({
-        manager,
+        txManager,
         userId,
         reviewId,
     }: {
-        manager: EntityManager;
+        txManager: EntityManager;
         userId: string;
         reviewId: string;
     }): Promise<boolean> {
         const lockQuery = `SELECT pg_try_advisory_xact_lock(hashtext($1)) AS acquired`;
         const lockKey = `${userId}-${reviewId}`;
-        const [lockResult] = await manager.query<{ acquired: boolean }[]>(lockQuery, [lockKey]);
+        const [lockResult] = await txManager.query<{ acquired: boolean }[]>(lockQuery, [lockKey]);
         return lockResult.acquired;
     }
 
     private async deleteVoteAndUpdateReviewTx(
         vote: Vote,
         reviewId: string,
-        manager: EntityManager,
+        txManager: EntityManager,
     ) {
-        await manager.withRepository(this.voteRepository).delete({ id: vote.id });
-        await this.reviewService.deleteVoteTx(reviewId, vote.action, manager);
+        await txManager.withRepository(this.voteRepository).delete({ id: vote.id });
+        await this.reviewService.decrementVotesTx({
+            reviewId,
+            action: vote.action,
+            txManager,
+            value: 1,
+        });
     }
 
     async voteReview(reviewId: string, user: AuthenticatedUser, action: VoteAction): Promise<void> {
-        await this.dataSource.transaction(async (manager: EntityManager) => {
-            await this.reviewService.existsOrThrowTx(reviewId, manager);
+        await this.dataSource.transaction(async (txManager: EntityManager) => {
+            await this.reviewService.existsOrThrowTx(reviewId, txManager);
             const acquired = await this.acquireVoteLock({
-                manager,
+                txManager,
                 userId: user.id,
                 reviewId,
             });
             if (!acquired) return;
-            const previousVote = await manager.withRepository(this.voteRepository).findOne({
+            const previousVote = await txManager.withRepository(this.voteRepository).findOne({
                 where: { relatedReview: reviewId, createdBy: user.id },
             });
             if (previousVote) {
                 if (previousVote.action === action) return;
-                await this.deleteVoteAndUpdateReviewTx(previousVote, reviewId, manager);
+                await this.deleteVoteAndUpdateReviewTx(previousVote, reviewId, txManager);
             }
             // add vote
-            await manager.withRepository(this.voteRepository).save({
+            await txManager.withRepository(this.voteRepository).save({
                 action,
                 createdBy: user.id,
                 relatedReview: reviewId,
             });
-            await this.reviewService.addVoteTx(reviewId, action, manager);
+            await this.reviewService.incrementVotesTx({
+                reviewId,
+                action,
+                txManager,
+                value: 1,
+            });
         });
         this.loggerService.info(`User ${user.id} ${action}voted review ${reviewId}`);
     }
@@ -80,18 +90,18 @@ export class VotesService {
     async deleteVote(reviewId: string, user: AuthenticatedUser): Promise<boolean> {
         await this.reviewService.existsOrThrow(reviewId);
         let deleted = false;
-        await this.dataSource.transaction(async (manager: EntityManager) => {
+        await this.dataSource.transaction(async (txManager: EntityManager) => {
             const acquired = await this.acquireVoteLock({
-                manager,
+                txManager,
                 userId: user.id,
                 reviewId,
             });
             if (!acquired) return;
-            const previousVote = await manager.withRepository(this.voteRepository).findOne({
+            const previousVote = await txManager.withRepository(this.voteRepository).findOne({
                 where: { relatedReview: reviewId, createdBy: user.id },
             });
             if (!previousVote) return;
-            await this.deleteVoteAndUpdateReviewTx(previousVote, reviewId, manager);
+            await this.deleteVoteAndUpdateReviewTx(previousVote, reviewId, txManager);
             deleted = true;
         });
         if (deleted) {
@@ -115,22 +125,22 @@ export class VotesService {
         });
     }
 
-    async subtractUserVotesFromReviews(userId: string, manager: EntityManager): Promise<void> {
-        const votes = await manager.withRepository(this.voteRepository).find({
+    async subtractUserVotesFromReviews(userId: string, txManager: EntityManager): Promise<void> {
+        const votes = await txManager.withRepository(this.voteRepository).find({
             where: { createdBy: userId },
             select: ['relatedReview', 'action'],
         });
         const upVotes = votes.filter((v) => v.action === VoteAction.UP);
         const downVotes = votes.filter((v) => v.action === VoteAction.DOWN);
-        await this.reviewService.deleteVoteInMultipleReviews(
-            upVotes.map((v) => v.relatedReview),
-            VoteAction.UP,
-            manager,
-        );
-        await this.reviewService.deleteVoteInMultipleReviews(
-            downVotes.map((v) => v.relatedReview),
-            VoteAction.DOWN,
-            manager,
-        );
+        await this.reviewService.decrementVotesInTx({
+            reviewsIds: upVotes.map((v) => v.relatedReview),
+            action: VoteAction.UP,
+            txManager,
+        });
+        await this.reviewService.decrementVotesInTx({
+            reviewsIds: downVotes.map((v) => v.relatedReview),
+            action: VoteAction.DOWN,
+            txManager,
+        });
     }
 }

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -125,7 +125,7 @@ export class VotesService {
         });
     }
 
-    async subtractUserVotesFromReviews(userId: string, txManager: EntityManager): Promise<void> {
+    async revokeUserVotesOnReviewsTx(userId: string, txManager: EntityManager): Promise<void> {
         const votes = await txManager.withRepository(this.voteRepository).find({
             where: { createdBy: userId },
             select: ['relatedReview', 'action'],

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -136,11 +136,13 @@ export class VotesService {
             reviewsIds: upVotes.map((v) => v.relatedReview),
             action: VoteAction.UP,
             txManager,
+            value: 1,
         });
         await this.reviewService.decrementVotesInTx({
             reviewsIds: downVotes.map((v) => v.relatedReview),
             action: VoteAction.DOWN,
             txManager,
+            value: 1,
         });
     }
 }

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AuthenticatedUser } from 'src/auth/interfaces/authenticated-user.interface';
-import { User } from 'src/users/entities/user.entity';
 import { Vote } from './entities/vote.entity';
 import { DataSource, EntityManager, Repository } from 'typeorm';
 import { VoteAction } from './enum/vote.enum';
@@ -23,16 +22,23 @@ export class VotesService {
     ) {}
 
     /**
-     * All the transactions by the same user will happen sequentially.
-     * This prevents race conditions if a user votes/downvotes/delete-votes multiple times in a short period.
+     * Creates an Advisory Lock for user-review.
+     * Reference: https://www.postgresql.org/docs/9.1/functions-admin.html#FUNCTIONS-ADVISORY-LOCKS
+     * @returns boolean indicating whether the lock was acquired or not.
      */
-    private async lockUserTx(userId: string, manager: EntityManager) {
-        await manager
-            .getRepository(User)
-            .createQueryBuilder('user')
-            .setLock('pessimistic_write')
-            .where('user.id = :id', { id: userId })
-            .getOne();
+    async acquireVoteLock({
+        manager,
+        userId,
+        reviewId,
+    }: {
+        manager: EntityManager;
+        userId: string;
+        reviewId: string;
+    }): Promise<boolean> {
+        const lockQuery = `SELECT pg_try_advisory_xact_lock(hashtext($1)) AS acquired`;
+        const lockKey = `${userId}-${reviewId}`;
+        const [lockResult] = await manager.query<{ acquired: boolean }[]>(lockQuery, [lockKey]);
+        return lockResult.acquired;
     }
 
     private async deleteVoteAndUpdateReviewTx(
@@ -47,7 +53,12 @@ export class VotesService {
     async voteReview(reviewId: string, user: AuthenticatedUser, action: VoteAction): Promise<void> {
         await this.dataSource.transaction(async (manager: EntityManager) => {
             await this.reviewService.existsOrThrowTx(reviewId, manager);
-            await this.lockUserTx(user.id, manager); // one at a time per user
+            const acquired = await this.acquireVoteLock({
+                manager,
+                userId: user.id,
+                reviewId,
+            });
+            if (!acquired) return;
             const previousVote = await manager.withRepository(this.voteRepository).findOne({
                 where: { relatedReview: reviewId, createdBy: user.id },
             });
@@ -70,7 +81,12 @@ export class VotesService {
         await this.reviewService.existsOrThrow(reviewId);
         let deleted = false;
         await this.dataSource.transaction(async (manager: EntityManager) => {
-            await this.lockUserTx(user.id, manager); // one at a time per user
+            const acquired = await this.acquireVoteLock({
+                manager,
+                userId: user.id,
+                reviewId,
+            });
+            if (!acquired) return;
             const previousVote = await manager.withRepository(this.voteRepository).findOne({
                 where: { relatedReview: reviewId, createdBy: user.id },
             });

--- a/testing/suites/integration/specs/votes/vote-review.test.ts
+++ b/testing/suites/integration/specs/votes/vote-review.test.ts
@@ -345,7 +345,8 @@ describe('Gql - voteReview', () => {
                 .map(() =>
                     testKit.gqlClient
                         .send(voteReview({ args: { reviewId: reviewId, vote: inputVotes.UP } }))
-                        .set('Cookie', sessionCookie),
+                        .set('Cookie', sessionCookie)
+                        .expect(success),
                 );
             await Promise.all(votePromises);
             // should exist only 1 vote with UP action
@@ -374,7 +375,8 @@ describe('Gql - voteReview', () => {
                 .map(() =>
                     testKit.gqlClient
                         .send(voteReview({ args: { reviewId: reviewId, vote: inputVotes.DOWN } }))
-                        .set('Cookie', sessionCookie),
+                        .set('Cookie', sessionCookie)
+                        .expect(success),
                 );
             await Promise.all(votePromises);
             // should exist only 1 vote with DOWN action


### PR DESCRIPTION
# Pull Request

## Description
A **pessimistic write lock** is locking the user row entirely. The new **Advisory Lock** ensures only one process handles that specific vote without ever freezing the actual user row for other unrelated queries.

## Changes Overview
- Replaced **pessimistic write lock**  for an **advisory lock**.
- Refactored methods in reviews and votes service for better readability.
- Added missing >=200 req status expectation in some votes tests.

## Type of Change
- [ ] **Bug fix** 
- [x] **New feature** 
- [ ] **Breaking change**
- [ ] **Refactor** 
- [ ] **Test** 
- [ ] **Documentation**

## Test Coverage
- [ ] Unit tests
- [ ] Components tests
- [ ] Integration tests
- [ ] E2E tests
- [x] No new tests required