### PR TITLE
Feat/new migration command ts only

### DIFF
--- a/db/data-source.ts
+++ b/db/data-source.ts
@@ -1,9 +1,13 @@
 import { DataSource } from 'typeorm';
+import { join } from 'path';
+
+const migrationsPath = join(__dirname, 'migrations', '*.ts');
+const entitiesPath = join(__dirname, '..', 'src', '**', '*.entity.ts');
 
 export default new DataSource({
     url: process.env.POSTGRES_URI,
     synchronize: false,
-    entities: ['dist/**/*.entity.js'],
+    entities: [entitiesPath],
     type: 'postgres',
-    migrations: ['dist/db/migrations/*.js'],
+    migrations: [migrationsPath],
 });

--- a/docker/base.compose.yml
+++ b/docker/base.compose.yml
@@ -79,8 +79,8 @@ services:
     pull_policy: never
     build:
       context: ..
-      target: development   
-    command: sh -c "npx nest build && npx typeorm -d dist/db/data-source.js migration:run"    
+      target: development    
+    command: sh -c "npx typeorm-ts-node-commonjs migration:run -d ./db/data-source.ts"    
     volumes:
       - ../db:/usr/src/app/db
     depends_on:
@@ -88,3 +88,4 @@ services:
         condition: service_healthy  
     environment:
       POSTGRES_URI: postgresql://dev:secretpassword@postgres:5432/ratewise         
+      NODE_OPTIONS: "--require tsconfig-paths/register"

--- a/testing/suites/integration/setup/global/containers/helpers/run-migration.helper.ts
+++ b/testing/suites/integration/setup/global/containers/helpers/run-migration.helper.ts
@@ -6,8 +6,12 @@ const exec = promisify(execCb);
 export async function runMigration(targetUri: string) {
     console.log('\n');
     console.log('\x1b[34m%s\x1b[0m', 'Running migration...');
-    await exec(`npx nest build && npx typeorm -d dist/db/data-source.js migration:run`, {
-        env: { ...process.env, POSTGRES_URI: targetUri },
+    await exec(`npx typeorm-ts-node-commonjs migration:run -d ./db/data-source.ts`, {
+        env: {
+            ...process.env,
+            POSTGRES_URI: targetUri,
+            NODE_OPTIONS: '--require tsconfig-paths/register',
+        },
         cwd: process.cwd(),
     });
     console.log('\x1b[32m%s\x1b[0m', 'Migration executed successfully');


### PR DESCRIPTION
# Pull Request

## Description
Update the migration command so that it only uses TypeScript files without needing to build.
Closes #215 

## Changes Overview
- Updated migration command in compose file and integration tests setup.
- Updated `db/data-source.ts` with full migrations and entities path.

## Type of Change
- [ ] **Bug fix** 
- [x] **New feature** 
- [ ] **Breaking change**
- [ ] **Refactor** 
- [ ] **Test** 
- [ ] **Documentation**

## Test Coverage
- [ ] Unit tests
- [ ] Components tests
- [ ] Integration tests
- [ ] E2E tests
- [x] No new tests required